### PR TITLE
patch: Do not instantiate model in settings.py

### DIFF
--- a/backend/server/extraction_runnable.py
+++ b/backend/server/extraction_runnable.py
@@ -18,8 +18,11 @@ from db.models import Example, Extractor
 from extraction.utils import (
     convert_json_schema_to_openai_schema,
 )
-from server.settings import CHUNK_SIZE, MODEL_NAME, model
+from server.settings import CHUNK_SIZE, MODEL_NAME, get_model
 from server.validators import validate_json_schema
+
+# Instantiate the model
+model = get_model()
 
 
 class ExtractionExample(BaseModel):

--- a/backend/server/main.py
+++ b/backend/server/main.py
@@ -3,8 +3,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from langserve import add_routes
-from sqlalchemy.orm import Session
-from typing_extensions import Annotated
 
 from server.api import examples, extract, extractors
 from server.extraction_runnable import (

--- a/backend/server/settings.py
+++ b/backend/server/settings.py
@@ -21,4 +21,6 @@ def get_postgres_url():
     return url
 
 
-model = ChatOpenAI(model=MODEL_NAME, temperature=0)
+def get_model() -> ChatOpenAI:
+    """Get the model."""
+    return ChatOpenAI(model=MODEL_NAME, temperature=0)


### PR DESCRIPTION
This makes sure we don't to do instantiation when running database migration
scripts (which definitely don't need openai api keys!)
