### PR TITLE
update poetry install in dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,7 +23,7 @@ RUN set -eux && \
       python3-dev \
       libmagic1
 
-# https://python-poetry.org/docs/master/#installing-with-the-official-installer
+# https://python-poetry.org/docs
 RUN pip install poetry
 
 # install deps before copying project files so the cache is only invalidated

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,8 +24,7 @@ RUN set -eux && \
       libmagic1
 
 # https://python-poetry.org/docs/master/#installing-with-the-official-installer
-RUN curl -sSL https://install.python-poetry.org | python -
-ENV PATH="$POETRY_HOME/bin:$PATH"
+RUN pip install poetry
 
 # install deps before copying project files so the cache is only invalidated
 # when the deps change


### PR DESCRIPTION
Running on a 2023 macbook pro I get an SSL issue during the poetry installation step:
> Could not fetch URL https://pypi.org/simple/poetry/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/poetry/ (Caused by SSLError("Can't connect to HTTPS URL because the SSL module is not available."))

Installing via pip appears to fix it.